### PR TITLE
feat: enable alarm scheduling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="your.package.name">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="nagomin.alarm1_2.team_alarm1_2">
 
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:targetApi="33"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" tools:targetApi="31"/>
 
     <application
         android:label="wakegrid"

--- a/android/app/src/main/kotlin/nagomin/alarm1_2/team_alarm1_2/MainActivity.kt
+++ b/android/app/src/main/kotlin/nagomin/alarm1_2/team_alarm1_2/MainActivity.kt
@@ -1,4 +1,4 @@
-package your.package.name
+package nagomin.alarm1_2.team_alarm1_2
 
 import android.app.AlarmManager
 import android.content.Context

--- a/lib/android/exact_alarm.dart
+++ b/lib/android/exact_alarm.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+
+/// Provides access to Android's exact alarm permission.
+///
+/// These methods are no-ops on non-Android platforms.
+class ExactAlarm {
+  ExactAlarm._();
+  static const MethodChannel _channel = MethodChannel('exact_alarm');
+
+  /// Returns whether the app is allowed to schedule exact alarms.
+  static Future<bool> canSchedule() async {
+    if (!Platform.isAndroid) return true;
+    final result =
+        await _channel.invokeMethod<bool>('canScheduleExactAlarms');
+    return result ?? false;
+  }
+
+  /// Opens the platform settings screen to grant exact alarm permission.
+  static Future<void> openSettings() async {
+    if (!Platform.isAndroid) return;
+    await _channel.invokeMethod('openExactAlarmSettings');
+  }
+}
+

--- a/lib/core/wake_status.dart
+++ b/lib/core/wake_status.dart
@@ -1,4 +1,6 @@
 //状態判断
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 enum WakeCellStatus { noAlarm, waiting, due, lateSuspicious, posted }
 
 class TodayAlarm {

--- a/lib/notifications/notification_service.dart
+++ b/lib/notifications/notification_service.dart
@@ -25,8 +25,9 @@ class NotificationService {
       await _fln.resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>()
           ?.requestPermissions(alert: true, badge: true, sound: true);
     } else if (Platform.isAndroid) {
-      await _fln.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
-          ?.requestPermission();
+      _fln
+          .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+          ?.requestNotificationsPermission();
     }
   }
 
@@ -41,7 +42,8 @@ class NotificationService {
       category: AndroidNotificationCategory.alarm, fullScreenIntent: true,
     );
     const ios = DarwinNotificationDetails(
-      presentAlert: true, presentSound: true, interruptionLevel: InterruptionLevel.timeSensitive,
+      presentAlert: true,
+      presentSound: true,
     );
     await _fln.zonedSchedule(
       id, title ?? 'おはようの時間です', body ?? 'グリッドに投稿しましょう', t,
@@ -61,7 +63,10 @@ class NotificationService {
       importance: Importance.max, priority: Priority.high, playSound: true,
       category: AndroidNotificationCategory.alarm, fullScreenIntent: true,
     );
-    const ios = DarwinNotificationDetails(presentAlert: true, presentSound: true, interruptionLevel: InterruptionLevel.timeSensitive);
+    const ios = DarwinNotificationDetails(
+      presentAlert: true,
+      presentSound: true,
+    );
     await _fln.zonedSchedule(
       id, title ?? 'スヌーズ', body ?? 'そろそろ起きる時間です', next,
       const NotificationDetails(android: android, iOS: ios),


### PR DESCRIPTION
## Summary
- simplify iOS notification details to avoid unsupported interruption level
- remove unused import from group grid screen
- add method channel based ExactAlarm helper for Android permissions
- resolve build errors by removing unnecessary await and importing settings screen
- use `requestNotificationsPermission` on Android to request notification runtime permission
- declare manifest package so `MainActivity` resolves correctly
- target new Android APIs in manifest and drop unused `USE_EXACT_ALARM` permission
- enable alarm scheduling from the group grid with a time picker and Firestore persistence

## Testing
- `dart format lib/ui/group_grid_screen.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ab0b9308322a813e825f00e12e6