### PR TITLE
feat: support multiple groups and invites

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 
-import 'ui/group_grid_screen.dart';
-import 'ui/chat_screen.dart';
-import 'ui/group_settings_screen.dart';
+import 'ui/group_list_screen.dart';
 import 'notifications/notification_service.dart';
 
 void main() async {
@@ -15,7 +12,6 @@ void main() async {
   runApp(const MyApp());
 }
 
-// ★ デモ用：任意のユーザーIDを固定（本番はFirebase Authを入れてください）
 const demoMyUid = 'user_a';
 
 class MyApp extends StatelessWidget {
@@ -25,53 +21,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'WakeGrid',
       theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.indigo),
-      home: const DemoHome(),
-      routes: {
-        '/chat': (_) => const SizedBox(),
-        '/settings': (_) => const SizedBox(),
-      },
+      home: const GroupListScreen(myUid: demoMyUid),
     );
-  }
-}
-
-class DemoHome extends StatefulWidget {
-  const DemoHome({super.key});
-  @override
-  State<DemoHome> createState() => _DemoHomeState();
-}
-
-class _DemoHomeState extends State<DemoHome> {
-  String? groupId;
-  List<String> members = const ['user_a','user_b','user_c'];
-
-  @override
-  void initState() {
-    super.initState();
-    _ensureDemoGroup();
-  }
-
-  Future<void> _ensureDemoGroup() async {
-    final db = FirebaseFirestore.instance;
-    final ref = db.collection('groups').doc('demo_group');
-    final doc = await ref.get();
-    if (!doc.exists) {
-      await ref.set({
-        'name': 'デモグループ',
-        'members': members,
-        'admins': ['user_a'],
-        'gridActiveSince': FieldValue.serverTimestamp(),
-        'gridExpiresAt': FieldValue.serverTimestamp(),
-        'settings': {'graceMins': 10, 'snoozeStepMins': 5, 'snoozeWarnThreshold': 2},
-      });
-    }
-    setState(() => groupId = 'demo_group');
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (groupId == null) {
-      return const Scaffold(body: Center(child: CircularProgressIndicator()));
-    }
-    return GroupGridScreen(groupId: groupId!, memberUids: members, myUid: demoMyUid);
   }
 }

--- a/lib/ui/group_invite_screen.dart
+++ b/lib/ui/group_invite_screen.dart
@@ -1,0 +1,33 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class GroupInviteScreen extends StatelessWidget {
+  final String groupId;
+  const GroupInviteScreen({super.key, required this.groupId});
+
+  @override
+  Widget build(BuildContext context) {
+    final ref = FirebaseFirestore.instance.collection('groups').doc(groupId);
+    return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+      stream: ref.snapshots(),
+      builder: (_, snap) {
+        final data = snap.data?.data() ?? {};
+        final code = data['inviteCode'] as String? ?? '';
+        return Scaffold(
+          appBar: AppBar(title: const Text('招待コード')),
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SelectableText(code, style: const TextStyle(fontSize: 24)),
+                const SizedBox(height: 16),
+                if (code.isNotEmpty) QrImageView(data: code, size: 200),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/group_list_screen.dart
+++ b/lib/ui/group_list_screen.dart
@@ -1,0 +1,130 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../data/group_repo.dart';
+import 'group_grid_screen.dart';
+import 'qr_scan_screen.dart';
+
+class GroupListScreen extends StatelessWidget {
+  final String myUid;
+  const GroupListScreen({super.key, required this.myUid});
+
+  @override
+  Widget build(BuildContext context) {
+    final qs = FirebaseFirestore.instance
+        .collection('groups')
+        .where('members', arrayContains: myUid)
+        .snapshots();
+    return Scaffold(
+      appBar: AppBar(title: const Text('グループ一覧')),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: qs,
+        builder: (_, snap) {
+          final docs = snap.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('グループがありません'));
+          }
+          return ListView(
+            children: [
+              for (final d in docs)
+                ListTile(
+                  title: Text(d.data()['name'] ?? d.id),
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => GroupGridScreen(groupId: d.id, myUid: myUid),
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          FloatingActionButton(
+            heroTag: 'create',
+            onPressed: () => _createGroup(context),
+            child: const Icon(Icons.add),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton(
+            heroTag: 'join',
+            onPressed: () => _joinGroup(context),
+            child: const Icon(Icons.group_add),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _createGroup(BuildContext context) async {
+    final c = TextEditingController();
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('グループ作成'),
+        content: TextField(
+          controller: c,
+          decoration: const InputDecoration(labelText: '名前'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('キャンセル')),
+          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('作成')),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    final repo = GroupRepo();
+    final gid = await repo.createGroup(c.text.isEmpty ? '新しいグループ' : c.text, myUid);
+    if (!context.mounted) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => GroupGridScreen(groupId: gid, myUid: myUid)),
+    );
+  }
+
+  Future<void> _joinGroup(BuildContext context) async {
+    String? code = await showDialog<String>(
+      context: context,
+      builder: (_) {
+        final c = TextEditingController();
+        return AlertDialog(
+          title: const Text('グループに参加'),
+          content: TextField(
+            controller: c,
+            decoration: const InputDecoration(labelText: '招待コード'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                final scanned = await Navigator.push<String>(
+                  context,
+                  MaterialPageRoute(builder: (_) => const QrScanScreen()),
+                );
+                Navigator.pop(context, scanned);
+              },
+              child: const Text('QRスキャン'),
+            ),
+            TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
+            FilledButton(onPressed: () => Navigator.pop(context, c.text), child: const Text('参加')),
+          ],
+        );
+      },
+    );
+    if (code == null || code.isEmpty) return;
+    final repo = GroupRepo();
+    final gid = await repo.joinGroupByCode(code, myUid);
+    if (!context.mounted) return;
+    if (gid == null) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('グループが見つかりません')));
+    } else {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => GroupGridScreen(groupId: gid, myUid: myUid)),
+      );
+    }
+  }
+}

--- a/lib/ui/qr_scan_screen.dart
+++ b/lib/ui/qr_scan_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
+
+class QrScanScreen extends StatefulWidget {
+  const QrScanScreen({super.key});
+  @override
+  State<QrScanScreen> createState() => _QrScanScreenState();
+}
+
+class _QrScanScreenState extends State<QrScanScreen> {
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  QRViewController? controller;
+
+  void _onQRViewCreated(QRViewController controller) {
+    this.controller = controller;
+    controller.scannedDataStream.listen((scanData) {
+      controller.pauseCamera();
+      Navigator.pop(context, scanData.code);
+    });
+  }
+
+  @override
+  void dispose() {
+    controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('QRコードをスキャン')),
+      body: QRView(key: qrKey, onQRViewCreated: _onQRViewCreated),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,10 @@ dependencies:
   firebase_storage: ^12.3.1
   firebase_messaging: ^15.1.2
 
+  # QR codes
+  qr_flutter: ^4.1.0
+  qr_code_scanner: ^1.0.1
+
   # 画像
   image_picker: ^1.1.2
 


### PR DESCRIPTION
## Summary
- add QR code dependencies
- implement group creation, joining via code or QR
- show invite code/QR and list groups dynamically

## Testing
- `dart format lib/main.dart lib/data/group_repo.dart lib/ui/group_grid_screen.dart lib/ui/group_list_screen.dart lib/ui/group_invite_screen.dart lib/ui/qr_scan_screen.dart` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b50e18897083228670c9a5db9d5b50